### PR TITLE
Allow AV_PIX_FMT_YUVJ420P and AV_PIX_FMT_YUVJ422P pixel formats

### DIFF
--- a/c_src/membrane_element_ffmpeg_h264/decoder.c
+++ b/c_src/membrane_element_ffmpeg_h264/decoder.c
@@ -148,9 +148,11 @@ UNIFEX_TERM flush(UnifexEnv *env, State *state) {
 UNIFEX_TERM get_metadata(UnifexEnv* env, UnifexNifState* state) {
   char * pix_format;
   switch (state->codec_ctx->pix_fmt) {
+  case AV_PIX_FMT_YUVJ420P:
   case AV_PIX_FMT_YUV420P:
     pix_format = "I420";
     break;
+  case AV_PIX_FMT_YUVJ422P:
   case AV_PIX_FMT_YUV422P:
     pix_format = "I422";
     break;


### PR DESCRIPTION
according to [this](https://libav.org/documentation/doxygen/master/pixfmt_8h.html#a9a8e335cf3be472042bc9f0cf80cd4c5aef61d7a65003ef618420f618294107b0) document these pixel formats are deprecated but compatible formats. I've tested this and it seems to work.